### PR TITLE
fix: multiple syntax errors in pillar.example

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -1,10 +1,8 @@
 # -*- coding: utf-8 -*-
 # vim: ft=yaml
----
 # ========
 # netbox
 # ========
----
 
 netbox:
   service:
@@ -96,7 +94,7 @@ netbox:
       DATETIME_FORMAT: 'N j, Y g:i a'
       SHORT_DATETIME_FORMAT: 'Y-m-d H:i'
       PLUGINS: []
-      PLUGINS_CONFIG: []
+      PLUGINS_CONFIG: {}
     optional:
       plugins:
         - pypi_name
@@ -109,7 +107,7 @@ netbox:
           AUTH_LDAP_BIND_DN: "\"CN=NETBOXSA, OU=Service Accounts,DC=example,DC=com\""
           AUTH_LDAP_BIND_PASSWORD: "\"demo\""
           LDAP_IGNORE_CERT_ERRORS: True
-          AUTH_LDAP_START_TLS = True
+          AUTH_LDAP_START_TLS: True
           AUTH_LDAP_USER_SEARCH: LDAPSearch("ou=Users,dc=example,dc=com",ldap.SCOPE_SUBTREE,"(sAMAccountName=%(user)s)")
           AUTH_LDAP_USER_DN_TEMPLATE: "\"uid=%(user)s,ou=users,dc=example,dc=com\""
           AUTH_LDAP_USER_ATTR_MAP:
@@ -139,4 +137,4 @@ netbox:
     url: https://github.com/netbox-community/netbox.git
     branch: master
   #Used to overwrite the default root if formula is not in root directory
-  tplroot_overwrite: None
+  #tplroot_overwrite: None


### PR DESCRIPTION
Hello,

my Saltstack is complaining about some things in the example pillar:

- Salt only wants one YAML document per file, the `---` lines had to go.
- As soon as plugins are used in the formula, the `PLUGINS_CONFIG` line throws an error because this variable is accessed as a dictionary `{}` even if the variable is empty.
- `tplroot_overwrite` is of type string in the original case, so "None" is used as the path. Maybe 'None' can be used in this pillar, this returns a real None.